### PR TITLE
Add support for lifespan state

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -1,20 +1,19 @@
 import logging
-from itertools import chain
 from contextlib import ExitStack
+from itertools import chain
 from typing import List, Optional, Type
 
-from mangum.protocols import HTTPCycle, LifespanCycle
-from mangum.handlers import ALB, HTTPGateway, APIGateway, LambdaAtEdge
 from mangum.exceptions import ConfigurationError
+from mangum.handlers import ALB, APIGateway, HTTPGateway, LambdaAtEdge
+from mangum.protocols import HTTPCycle, LifespanCycle
 from mangum.types import (
     ASGI,
-    LifespanMode,
     LambdaConfig,
-    LambdaEvent,
     LambdaContext,
+    LambdaEvent,
     LambdaHandler,
+    LifespanMode,
 )
-
 
 logger = logging.getLogger("mangum")
 
@@ -74,12 +73,14 @@ class Mangum:
 
     def __call__(self, event: LambdaEvent, context: LambdaContext) -> dict:
         handler = self.infer(event, context)
+        scope = handler.scope
         with ExitStack() as stack:
             if self.lifespan in ("auto", "on"):
                 lifespan_cycle = LifespanCycle(self.app, self.lifespan)
                 stack.enter_context(lifespan_cycle)
+                scope |= {"state": lifespan_cycle.lifespan_state.copy()}
 
-            http_cycle = HTTPCycle(handler.scope, handler.body)
+            http_cycle = HTTPCycle(scope, handler.body)
             http_response = http_cycle(self.app)
 
             return handler(http_response)

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -78,7 +78,7 @@ class Mangum:
             if self.lifespan in ("auto", "on"):
                 lifespan_cycle = LifespanCycle(self.app, self.lifespan)
                 stack.enter_context(lifespan_cycle)
-                scope |= {"state": lifespan_cycle.lifespan_state.copy()}
+                scope.update({"state": lifespan_cycle.lifespan_state.copy()})
 
             http_cycle = HTTPCycle(scope, handler.body)
             http_response = http_cycle(self.app)

--- a/mangum/handlers/alb.py
+++ b/mangum/handlers/alb.py
@@ -104,7 +104,6 @@ class ALB:
 
     @property
     def scope(self) -> Scope:
-
         headers = transform_headers(self.event)
         list_headers = [list(x) for x in headers]
         # Unique headers. If there are duplicates, it will use the last defined.

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -93,7 +93,6 @@ class HTTPCycle:
             self.state is HTTPCycleState.RESPONSE
             and message["type"] == "http.response.body"
         ):
-
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
             self.buffer.write(body)

--- a/mangum/protocols/lifespan.py
+++ b/mangum/protocols/lifespan.py
@@ -2,7 +2,7 @@ import asyncio
 import enum
 import logging
 from types import TracebackType
-from typing import Optional, Type
+from typing import Optional, Type, Any
 
 from mangum.types import ASGI, LifespanMode, Message
 from mangum.exceptions import LifespanUnsupported, LifespanFailure, UnexpectedMessage
@@ -62,6 +62,7 @@ class LifespanCycle:
         self.startup_event: asyncio.Event = asyncio.Event()
         self.shutdown_event: asyncio.Event = asyncio.Event()
         self.logger = logging.getLogger("mangum.lifespan")
+        self.lifespan_state: dict[str, Any] = {}
 
     def __enter__(self) -> None:
         """Runs the event loop for application startup."""
@@ -81,7 +82,7 @@ class LifespanCycle:
         """Calls the application with the `lifespan` connection scope."""
         try:
             await self.app(
-                {"type": "lifespan", "asgi": {"spec_version": "2.0", "version": "3.0"}},
+                {"type": "lifespan", "asgi": {"spec_version": "2.0", "version": "3.0"}, "state": self.lifespan_state},
                 self.receive,
                 self.send,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ brotli
 brotli-asgi
 mkdocs
 mkdocs-material
+Hypercorn < 0.15.0 # to test python 3.7

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,14 +1,12 @@
 import logging
 
 import pytest
-
+from quart import Quart
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 
 from mangum import Mangum
 from mangum.exceptions import LifespanFailure
-
-from quart import Quart
 
 
 @pytest.mark.parametrize(
@@ -215,6 +213,58 @@ def test_lifespan_failure(mock_aws_api_gateway_event, lifespan, failure_type) ->
 
     with pytest.raises(LifespanFailure):
         handler(mock_aws_api_gateway_event, {})
+
+
+@pytest.mark.parametrize(
+    "mock_aws_api_gateway_event,lifespan_state,lifespan",
+    [
+        (["GET", None, None], {"test_key": "test_value"}, "auto"),
+        (["GET", None, None], {"test_key": "test_value"}, "on"),
+    ],
+    indirect=["mock_aws_api_gateway_event"],
+)
+def test_lifespan_state(mock_aws_api_gateway_event, lifespan_state, lifespan) -> None:
+    startup_complete = False
+    shutdown_complete = False
+
+    async def app(scope, receive, send):
+        nonlocal startup_complete, shutdown_complete
+
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    scope["state"].update(lifespan_state)
+                    await send({"type": "lifespan.startup.complete"})
+                    startup_complete = True
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    shutdown_complete = True
+                    return
+
+        if scope["type"] == "http":
+            assert lifespan_state.items() <= scope["state"].items()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [[b"content-type", b"text/plain; charset=utf-8"]],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+    handler = Mangum(app, lifespan=lifespan)
+    response = handler(mock_aws_api_gateway_event, {})
+
+    assert startup_complete
+    assert shutdown_complete
+    assert response == {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "headers": {"content-type": "text/plain; charset=utf-8"},
+        "multiValueHeaders": {},
+        "body": "Hello, world!",
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds support for lifespan state to mangum.
It's required to run fastapi / starlette.
https://www.starlette.io/lifespan/#lifespan-state

Tested working in AWS Lambda in shobotrust
https://github.com/HENNGE/shobotrust/pull/21/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R23

I wonder how do we release this to pypi 🤔 
Should we use a different name like `hennge-mangum`?

Also the upstream repo seems to be abandoned by the maintainer, maybe we should start maintain it ourselves (with this fork).